### PR TITLE
feat: improve sidebar ux

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,45 @@ kli --theme tokyonight    # switch theme
 
 Press `?` for help and `Ctrl+K` for the command palette.
 
+## Configuration
+
+`kli` reads an optional config file from `kli config path` (typically
+`~/.config/kli/config.yaml`, or `~/Library/Application Support/kli/config.yaml`
+on macOS). It is separate from the auto-saved context/namespace state and is only
+written by you or by `kli config init`.
+
+Today it customizes the left sidebar menu. When a `sidebar:` list is present it
+replaces the built-in default menu; without a config file the built-in defaults
+are used. Resources the cluster doesn't expose are dropped, and empty sections
+are hidden.
+
+Seed a starter file with the current defaults (refuses to overwrite without
+`--force`):
+
+```
+kli config init          # write the default config to populate from
+kli config path          # print the config file location
+```
+
+The `resource` field accepts anything the resource picker resolves: a plural,
+singular, kind, short name, or group-qualified key (e.g. `scaledobjects.keda.sh`).
+
+```yaml
+sidebar:
+  - section: Workloads
+    items:
+      - { label: Pods, resource: pods }
+      - { label: Deployments, resource: deployments }
+      - { label: HPAs, resource: horizontalpodautoscalers }   # opt-in
+      - { label: ScaledObjects, resource: scaledobjects }      # opt-in (KEDA)
+  - section: Network
+    items:
+      - { label: Services, resource: services }
+```
+
+`HPAs`, `ScaledObjects`, and `OtelCollectors` are not in the default menu; add
+them as above (a freshly seeded config lists them as commented examples).
+
 ## Highlights
 
 - A cockpit overview on launch: cluster health, node CPU and memory gauges, pod and deployment status, and recent warnings.
@@ -47,6 +86,7 @@ Press `?` for help and `Ctrl+K` for the command palette.
 - lazygit-style layout: a left resource nav, `Tab` between panes, and a status bar that always shows the keys that work right now.
 - Logs, edit-in-editor (applied on save), shell into a pod, delete, and scale, all in overlays inside the TUI.
 - ANSI colors that match your terminal in light or dark mode, with Tokyo Night as a fallback (`--theme tokyonight`).
+- A customizable sidebar menu via an optional config file (`kli config init`) — add CRDs like HPAs, KEDA ScaledObjects, or OpenTelemetry collectors.
 - Remembers your last context and namespace.
 
 ## Docs

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/charmbracelet/x/ansi v0.11.7
 	github.com/charmbracelet/x/vt v0.0.0-20260608090822-c3ad58c6c9e5
 	github.com/creack/pty v1.1.24
+	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.34.1
 	k8s.io/apimachinery v0.34.1
 	k8s.io/client-go v0.34.1
@@ -71,7 +72,6 @@ require (
 	google.golang.org/protobuf v1.36.5 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250710124328-f3f2b991d03b // indirect
 	k8s.io/utils v0.0.0-20250604170112-4c0f3b243397 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,6 @@ github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
-github.com/aymanbagabas/go-udiff v0.3.1 h1:LV+qyBQ2pqe0u42ZsUEtPiCaUoqgA9gYRDs3vj1nolY=
-github.com/aymanbagabas/go-udiff v0.3.1/go.mod h1:G0fsKmG+P6ylD0r6N/KgQD/nWzgfnl8ZBcNLgcbrw8E=
 github.com/charmbracelet/bubbles v1.0.0 h1:12J8/ak/uCZEMQ6KU7pcfwceyjLlWsDLAxB5fXonfvc=
 github.com/charmbracelet/bubbles v1.0.0/go.mod h1:9d/Zd5GdnauMI5ivUIVisuEm3ave1XwXtD1ckyV6r3E=
 github.com/charmbracelet/bubbletea v1.3.10 h1:otUDHWMMzQSB0Pkc87rm691KZ3SWa4KUlvF9nRvCICw=
@@ -20,8 +18,6 @@ github.com/charmbracelet/x/ansi v0.11.7 h1:kzv1kJvjg2S3r9KHo8hDdHFQLEqn4RBCb39dA
 github.com/charmbracelet/x/ansi v0.11.7/go.mod h1:9qGpnAVYz+8ACONkZBUWPtL7lulP9No6p1epAihUZwQ=
 github.com/charmbracelet/x/cellbuf v0.0.15 h1:ur3pZy0o6z/R7EylET877CBxaiE1Sp1GMxoFPAIztPI=
 github.com/charmbracelet/x/cellbuf v0.0.15/go.mod h1:J1YVbR7MUuEGIFPCaaZ96KDl5NoS0DAWkskup+mOY+Q=
-github.com/charmbracelet/x/exp/golden v0.0.0-20241011142426-46044092ad91 h1:payRxjMjKgx2PaCWLZ4p3ro9y97+TVLZNaRZgJwSVDQ=
-github.com/charmbracelet/x/exp/golden v0.0.0-20241011142426-46044092ad91/go.mod h1:wDlXFlCrmJ8J+swcL/MnGUuYnqgQdW9rhSD61oNMb6U=
 github.com/charmbracelet/x/exp/ordered v0.1.0 h1:55/qLwjIh0gL0Vni+QAWk7T/qRVP6sBf+2agPBgnOFE=
 github.com/charmbracelet/x/exp/ordered v0.1.0/go.mod h1:5UHwmG+is5THxMyCJHNPCn2/ecI07aKNrW+LcResjJ8=
 github.com/charmbracelet/x/term v0.2.2 h1:xVRT/S2ZcKdhhOuSP4t5cLi5o+JxklsoEObBSgfgZRk=

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -64,6 +64,7 @@ type App struct {
 	client *k8s.Client
 	theme  Theme
 	keys   keyMap
+	navCat []navCatGroup // sidebar catalog (from config or built-in defaults)
 
 	width, height int // usable area, inside the outer gutter
 	gutter        int // equal padding (cells) on every side
@@ -107,13 +108,14 @@ type App struct {
 }
 
 // NewApp builds the root model for a connected client.
-func NewApp(cl *k8s.Client, th Theme) App {
+func NewApp(cl *k8s.Client, th Theme, navCat []navCatGroup) App {
 	a := App{
 		client: cl,
 		theme:  th,
 		keys:   defaultKeys(),
+		navCat: navCat,
 	}
-	a.sidebar = newSidebar(th, cl.Registry())
+	a.sidebar = newSidebar(th, cl.Registry(), navCat)
 	a.cockpit = newCockpitView(th)
 	a.table = newTableView(th)
 	a.config = newConfigView(th)
@@ -1191,7 +1193,7 @@ func (a App) adoptClient(cl *k8s.Client) (tea.Model, tea.Cmd) {
 	a.client = cl
 	// Rebuild the left nav from the new cluster's catalog: available resource
 	// kinds differ between clusters, so the previous sidebar may be stale.
-	a.sidebar = newSidebar(a.theme, cl.Registry())
+	a.sidebar = newSidebar(a.theme, cl.Registry(), a.navCat)
 	a.namespace = cl.Namespace
 	a.lastNS = cl.Namespace
 	if a.lastNS == "" {

--- a/internal/ui/config.go
+++ b/internal/ui/config.go
@@ -1,0 +1,151 @@
+package ui
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Config is the user-authored configuration file (distinct from the auto-saved
+// state.json). It is read once at startup and never written by the running TUI;
+// only the user edits it, or `kli config init` seeds it. The first supported key
+// is the sidebar menu; the struct leaves room for more keys later.
+type Config struct {
+	Sidebar []SidebarSection `yaml:"sidebar,omitempty"`
+}
+
+// SidebarSection is one labeled group in the left nav (e.g. "Workloads").
+type SidebarSection struct {
+	Section string        `yaml:"section"`
+	Items   []SidebarItem `yaml:"items"`
+}
+
+// SidebarItem is one entry in a section. Resource is any string the resource
+// registry resolves: plural, singular, kind, short name, or group-qualified key
+// (e.g. "scaledobjects.keda.sh").
+type SidebarItem struct {
+	Label    string `yaml:"label"`
+	Resource string `yaml:"resource"`
+}
+
+// configPath is <os.UserConfigDir>/kli/config.yaml, the same directory as
+// state.json.
+func configPath() (string, error) {
+	dir, err := os.UserConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "kli", "config.yaml"), nil
+}
+
+// ConfigPath exposes the resolved config file path for the `kli config path`
+// subcommand.
+func ConfigPath() (string, error) { return configPath() }
+
+// loadConfig reads and parses the config file. A missing file is normal and
+// returns (zero, false, nil). A read or parse error returns (zero, false, err)
+// so the caller can warn and fall back to defaults.
+func loadConfig() (Config, bool, error) {
+	p, err := configPath()
+	if err != nil {
+		return Config{}, false, err
+	}
+	b, err := os.ReadFile(p)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return Config{}, false, nil
+		}
+		return Config{}, false, err
+	}
+	var cfg Config
+	if err := yaml.Unmarshal(b, &cfg); err != nil {
+		return Config{}, false, err
+	}
+	return cfg, true, nil
+}
+
+// sidebarCatalog converts the config's sidebar into the internal nav catalog.
+// It returns nil when no sections are defined, so the caller falls back to the
+// built-in defaults.
+func (c Config) sidebarCatalog() []navCatGroup {
+	if len(c.Sidebar) == 0 {
+		return nil
+	}
+	cat := make([]navCatGroup, 0, len(c.Sidebar))
+	for _, sec := range c.Sidebar {
+		items := make([]navCatItem, 0, len(sec.Items))
+		for _, it := range sec.Items {
+			items = append(items, navCatItem{label: it.Label, query: it.Resource})
+		}
+		cat = append(cat, navCatGroup{section: sec.Section, items: items})
+	}
+	return cat
+}
+
+// catalogConfig builds a Config from a nav catalog, used to serialize the
+// defaults for `kli config init`.
+func catalogConfig(cat []navCatGroup) Config {
+	cfg := Config{Sidebar: make([]SidebarSection, 0, len(cat))}
+	for _, g := range cat {
+		items := make([]SidebarItem, 0, len(g.items))
+		for _, it := range g.items {
+			items = append(items, SidebarItem{Label: it.label, Resource: it.query})
+		}
+		cfg.Sidebar = append(cfg.Sidebar, SidebarSection{Section: g.section, Items: items})
+	}
+	return cfg
+}
+
+// marshalConfig renders a Config as YAML with a compact 2-space indent and
+// declaration field order (so "section" precedes "items").
+func marshalConfig(cfg Config) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+	if err := enc.Encode(cfg); err != nil {
+		return nil, err
+	}
+	if err := enc.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// optInExamples is appended (commented out) to a seeded config so users can
+// discover and uncomment resources that are intentionally absent from the
+// defaults. As YAML comments it is inert when the file is parsed.
+const optInExamples = `
+# Opt-in examples — uncomment and add under the relevant section's items:
+#   - { label: HPAs, resource: horizontalpodautoscalers }
+#   - { label: ScaledObjects, resource: scaledobjects }   # KEDA
+#   - { label: OtelCollectors, resource: opentelemetrycollectors }
+`
+
+// WriteDefaultConfig seeds the config file with the built-in defaults plus a
+// trailing block of commented opt-in examples. It refuses to overwrite an
+// existing file unless force is true. It returns the path written.
+func WriteDefaultConfig(force bool) (string, error) {
+	p, err := configPath()
+	if err != nil {
+		return "", err
+	}
+	if !force {
+		if _, err := os.Stat(p); err == nil {
+			return p, fmt.Errorf("%s already exists; use --force to overwrite", p)
+		}
+	}
+	b, err := marshalConfig(catalogConfig(defaultNavCatalog()))
+	if err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		return "", err
+	}
+	if err := os.WriteFile(p, append(b, []byte(optInExamples)...), 0o644); err != nil {
+		return "", err
+	}
+	return p, nil
+}

--- a/internal/ui/config_test.go
+++ b/internal/ui/config_test.go
@@ -1,0 +1,92 @@
+package ui
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// parseConfig mirrors loadConfig's parsing without touching the filesystem.
+func parseConfig(t *testing.T, src string) Config {
+	t.Helper()
+	var cfg Config
+	if err := yaml.Unmarshal([]byte(src), &cfg); err != nil {
+		t.Fatalf("parse config: %v", err)
+	}
+	return cfg
+}
+
+func TestDefaultCatalogExcludesOptIns(t *testing.T) {
+	for _, g := range defaultNavCatalog() {
+		for _, it := range g.items {
+			switch it.query {
+			case "horizontalpodautoscalers", "scaledobjects", "opentelemetrycollectors":
+				t.Fatalf("default catalog must not include opt-in resource %q", it.query)
+			}
+		}
+	}
+}
+
+func TestCatalogConfigRoundTrip(t *testing.T) {
+	def := defaultNavCatalog()
+	b, err := marshalConfig(catalogConfig(def))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	cfg := parseConfig(t, string(b))
+	if got := cfg.sidebarCatalog(); !reflect.DeepEqual(got, def) {
+		t.Fatalf("round-trip mismatch:\n got=%+v\nwant=%+v", got, def)
+	}
+}
+
+func TestSidebarCatalogConvertsSectionsAndItems(t *testing.T) {
+	cfg := parseConfig(t, `
+sidebar:
+  - section: Workloads
+    items:
+      - { label: Pods, resource: pods }
+      - { label: HPAs, resource: horizontalpodautoscalers }
+  - section: Network
+    items:
+      - { label: Services, resource: services }
+`)
+	got := cfg.sidebarCatalog()
+	want := []navCatGroup{
+		{section: "Workloads", items: []navCatItem{
+			{label: "Pods", query: "pods"},
+			{label: "HPAs", query: "horizontalpodautoscalers"},
+		}},
+		{section: "Network", items: []navCatItem{
+			{label: "Services", query: "services"},
+		}},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("conversion mismatch:\n got=%+v\nwant=%+v", got, want)
+	}
+}
+
+func TestSidebarCatalogEmptyFallsBack(t *testing.T) {
+	// No sidebar key → nil, so the caller uses the built-in defaults.
+	if got := (Config{}).sidebarCatalog(); got != nil {
+		t.Fatalf("empty config should yield nil catalog, got %+v", got)
+	}
+}
+
+func TestOptInExamplesAreInertComments(t *testing.T) {
+	// The seeded file is "marshaled defaults" + commented examples; parsing the
+	// whole thing must yield exactly the defaults (comments are inert).
+	b, err := marshalConfig(catalogConfig(defaultNavCatalog()))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	full := string(b) + optInExamples
+	if !strings.Contains(optInExamples, "horizontalpodautoscalers") {
+		t.Fatalf("opt-in examples should mention the opt-in resources")
+	}
+	cfg := parseConfig(t, full)
+	if got := cfg.sidebarCatalog(); !reflect.DeepEqual(got, defaultNavCatalog()) {
+		t.Fatalf("commented examples leaked into parsed config:\n%+v", got)
+	}
+}

--- a/internal/ui/run.go
+++ b/internal/ui/run.go
@@ -35,7 +35,20 @@ func Run(opts Options) error {
 		return err
 	}
 
-	app := NewApp(cl, th)
+	// Resolve the sidebar catalog: a user config file replaces the built-in
+	// defaults; a malformed config is ignored (defaults kept) with a warning.
+	catalog := defaultNavCatalog()
+	cfg, found, cfgErr := loadConfig()
+	if found {
+		if c := cfg.sidebarCatalog(); len(c) > 0 {
+			catalog = c
+		}
+	}
+
+	app := NewApp(cl, th, catalog)
+	if cfgErr != nil {
+		app.setStatus("config: "+cfgErr.Error()+"; using defaults", true)
+	}
 	switch {
 	case opts.Namespace != "":
 		app.namespace = opts.Namespace

--- a/internal/ui/sidebar.go
+++ b/internal/ui/sidebar.go
@@ -13,38 +13,42 @@ type navCatGroup struct {
 	items   []navCatItem
 }
 
-// navCatalog is the curated, lazygit-style quick list. Entries that the cluster
-// does not expose are dropped, and empty sections are hidden.
-var navCatalog = []navCatGroup{
-	{"Workloads", []navCatItem{
-		{"Pods", "pods"},
-		{"Deployments", "deployments"},
-		{"StatefulSets", "statefulsets"},
-		{"DaemonSets", "daemonsets"},
-		{"ReplicaSets", "replicasets"},
-		{"Jobs", "jobs"},
-		{"CronJobs", "cronjobs"},
-	}},
-	{"Network", []navCatItem{
-		{"Services", "services"},
-		{"Ingresses", "ingresses"},
-		{"Endpoints", "endpoints"},
-	}},
-	{"Config", []navCatItem{
-		{"ConfigMaps", "configmaps"},
-		{"Secrets", "secrets"},
-		{"ServiceAccounts", "serviceaccounts"},
-	}},
-	{"Storage", []navCatItem{
-		{"PVCs", "persistentvolumeclaims"},
-		{"PVs", "persistentvolumes"},
-		{"StorageClasses", "storageclasses"},
-	}},
-	{"Cluster", []navCatItem{
-		{"Nodes", "nodes"},
-		{"Namespaces", "namespaces"},
-		{"Events", "events"},
-	}},
+// defaultNavCatalog is the curated, lazygit-style quick list used when the user
+// has no config file. Entries that the cluster does not expose are dropped, and
+// empty sections are hidden. Resources beyond these core ones (CRDs, autoscalers,
+// etc.) are opt-in via the config file — see config.go and `kli config init`.
+func defaultNavCatalog() []navCatGroup {
+	return []navCatGroup{
+		{"Workloads", []navCatItem{
+			{"Pods", "pods"},
+			{"Deployments", "deployments"},
+			{"StatefulSets", "statefulsets"},
+			{"DaemonSets", "daemonsets"},
+			{"ReplicaSets", "replicasets"},
+			{"Jobs", "jobs"},
+			{"CronJobs", "cronjobs"},
+		}},
+		{"Network", []navCatItem{
+			{"Services", "services"},
+			{"Ingresses", "ingresses"},
+			{"Endpoints", "endpoints"},
+		}},
+		{"Config", []navCatItem{
+			{"ConfigMaps", "configmaps"},
+			{"Secrets", "secrets"},
+			{"ServiceAccounts", "serviceaccounts"},
+		}},
+		{"Storage", []navCatItem{
+			{"PVCs", "persistentvolumeclaims"},
+			{"PVs", "persistentvolumes"},
+			{"StorageClasses", "storageclasses"},
+		}},
+		{"Cluster", []navCatItem{
+			{"Nodes", "nodes"},
+			{"Namespaces", "namespaces"},
+			{"Events", "events"},
+		}},
+	}
 }
 
 // overviewKey marks the sidebar entry that opens the cockpit dashboard.
@@ -68,14 +72,14 @@ type sidebar struct {
 	height     int
 }
 
-func newSidebar(th Theme, reg *k8s.Registry) sidebar {
+func newSidebar(th Theme, reg *k8s.Registry, catalog []navCatGroup) sidebar {
 	s := sidebar{th: th}
 
 	// The cockpit overview is the first, always-present entry.
 	s.selectable = append(s.selectable, len(s.entries))
 	s.entries = append(s.entries, navEntry{overview: true, label: "Overview", key: overviewKey})
 
-	for _, sec := range navCatalog {
+	for _, sec := range catalog {
 		var items []navEntry
 		for _, it := range sec.items {
 			ri, ok := reg.Resolve(it.query)

--- a/internal/ui/smoke_test.go
+++ b/internal/ui/smoke_test.go
@@ -75,7 +75,7 @@ func TestAppSmoke(t *testing.T) {
 
 	for _, themeName := range []string{"ansi", "tokyonight"} {
 		th := PickTheme(themeName)
-		app := NewApp(cl, th)
+		app := NewApp(cl, th, defaultNavCatalog())
 		var m tea.Model = app
 
 		// Try several terminal sizes including very small.

--- a/main.go
+++ b/main.go
@@ -27,6 +27,14 @@ func main() {
 		return
 	}
 
+	if len(os.Args) > 1 && os.Args[1] == "config" {
+		if err := runConfig(os.Args[2:]); err != nil {
+			fmt.Fprintln(os.Stderr, "error:", err)
+			os.Exit(1)
+		}
+		return
+	}
+
 	var (
 		ctxFlag, nsFlag, resFlag, themeFlag, kubeconfigFlag string
 		checkFlag, versionFlag                              bool
@@ -91,4 +99,36 @@ func check(ctxName, kubeconfig, ns, resQuery string) error {
 	}
 	fmt.Printf("listed %s: %d columns, %d rows\n", ri.Key(), len(tbl.Columns), len(tbl.Rows))
 	return nil
+}
+
+// runConfig handles the `kli config <subcommand>` family.
+func runConfig(args []string) error {
+	sub := ""
+	if len(args) > 0 {
+		sub = args[0]
+	}
+	switch sub {
+	case "init":
+		force := false
+		for _, a := range args[1:] {
+			if a == "--force" || a == "-f" {
+				force = true
+			}
+		}
+		path, err := ui.WriteDefaultConfig(force)
+		if err != nil {
+			return err
+		}
+		fmt.Println("wrote", path)
+		return nil
+	case "path":
+		path, err := ui.ConfigPath()
+		if err != nil {
+			return err
+		}
+		fmt.Println(path)
+		return nil
+	default:
+		return fmt.Errorf("usage: kli config <init [--force] | path>")
+	}
 }


### PR DESCRIPTION
# Configurable sidebar menu via a config file

## Summary

Adds an optional user config file (`~/.config/kli/config.yaml`) and uses it, as
its first feature, to define the left sidebar navigation menu. This lets users
add, remove, rename, and reorder sidebar entries — including arbitrary CRDs —
without recompiling.

The config file is intentionally general (`sidebar:` is the first top-level key),
leaving room for future settings.

## Behavior

- **No config file** → the built-in default menu is used, unchanged. Existing
  users see no difference.
- **Config file with a `sidebar:` list** → it fully replaces the built-in menu.
- **Malformed config** → kli keeps the defaults and shows a one-line warning in
  the status bar (never crashes or blocks startup).
- Entries whose `resource` does not resolve on the connected cluster are dropped,
  and empty sections are hidden — same as the existing hardcoded list.

The config file lives next to the existing `state.json` (via `os.UserConfigDir`)
and is **never written by the running TUI** — only by the user or `kli config
init`. It is separate from the auto-saved context/namespace state.

## Usage

```sh
kli config init          # seed a starter config with the current defaults
kli config init --force  # overwrite an existing config
kli config path          # print the config file location
```

Example `config.yaml` (a user who has opted in to extra resources):

```yaml
sidebar:
  - section: Workloads
    items:
      - { label: Pods, resource: pods }
      - { label: Deployments, resource: deployments }
      - { label: HPAs, resource: horizontalpodautoscalers }   # opt-in
      - { label: ScaledObjects, resource: scaledobjects }      # opt-in (KEDA)
  - section: Network
    items:
      - { label: Services, resource: services }
```

`resource` accepts anything the resource registry resolves: plural, singular,
kind, short name, or group-qualified key (e.g. `scaledobjects.keda.sh`) — the
same strings the resource jump/palette already accept.

A freshly seeded config contains the default menu plus a commented block of
opt-in examples (HPAs, KEDA ScaledObjects, OpenTelemetry collectors) so they are
discoverable without shipping them in the default menu.

## Implementation

- **`internal/ui/config.go`** (new) — `Config`/`SidebarSection`/`SidebarItem`
  types, `loadConfig`, `sidebarCatalog()` (config → nav catalog),
  `WriteDefaultConfig`, and `ConfigPath`. Parsed/serialized with
  `gopkg.in/yaml.v3` (already in the module graph; promoted to a direct
  dependency).
- **`internal/ui/sidebar.go`** — the hardcoded `navCatalog` var becomes
  `defaultNavCatalog()`; `newSidebar` takes the catalog as a parameter.
- **`internal/ui/run.go` / `app.go`** — load the config at startup, pick the
  catalog (config-or-default), store it on the app, and reuse it when the sidebar
  is rebuilt on context switch.
- **`main.go`** — `kli config init [--force]` and `kli config path` subcommands.
- **`README.md`** — documents the config file and subcommands.

## Testing

- New `internal/ui/config_test.go`: defaults exclude opt-in resources, marshal →
  parse round-trips to the defaults, section/item conversion, empty-config
  fallback, and that the seeded commented examples are inert when parsed.
- Existing tests updated for the `newSidebar`/`NewApp` signature change.
- `go build ./...`, `go vet ./...`, `go test ./...`, and `gofmt` all clean.

## Notes

- No new runtime dependency is linked: `gopkg.in/yaml.v3` was already pulled in
  transitively; this only promotes it to a direct dependency. Binary size
  increase is ~65 KB (~0.14%).
- Backward compatible: with no config file, behavior is identical to today.
- Scope is intentionally limited to the `sidebar:` key. No live reload,
  per-context configs, or other config keys yet — the structure just leaves room
  for them.
