### PR TITLE
Scroll table columns horizontally on small screens

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -754,10 +754,25 @@ func (a App) updateSidebarKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 func (a App) updateMainKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch {
-	case msg.String() == "left" || msg.String() == "h":
+	case msg.String() == "left":
+		// Scroll the table left first; only jump to the sidebar once it is already
+		// at its leftmost column, so wide tables stay reachable on small screens.
+		if a.table.scrollLeft() {
+			return a, nil
+		}
 		if a.sidebarVisible() {
 			a.focus = focusSidebar
 		}
+		return a, nil
+	case msg.String() == "h":
+		// h keeps its original meaning (focus the sidebar); only the arrows scroll.
+		if a.sidebarVisible() {
+			a.focus = focusSidebar
+		}
+		return a, nil
+	case msg.String() == "right":
+		// `l` is the Logs shortcut, so only the right arrow scrolls columns.
+		a.table.scrollRight()
 		return a, nil
 	case key.Matches(msg, a.keys.Enter):
 		return a.openConfig()
@@ -944,7 +959,8 @@ func (a *App) useResource(ri k8s.ResourceInfo) {
 	a.focus = focusMain
 	a.sidebar.syncTo(ri.Key())
 	a.table.stopFilter(true)
-	a.table.resetSort() // columns differ per resource
+	a.table.resetSort()    // columns differ per resource
+	a.table.resetHScroll() // restart horizontal scroll from the left
 	a.table.setData(nil)
 }
 

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -14,6 +14,7 @@ type keyMap struct {
 	HalfDown key.Binding
 	Top      key.Binding
 	Bottom   key.Binding
+	HScroll  key.Binding
 
 	// row actions
 	Enter      key.Binding
@@ -60,6 +61,7 @@ func defaultKeys() keyMap {
 		HalfDown: key.NewBinding(key.WithKeys("ctrl+d"), key.WithHelp("^d", "½ page down")),
 		Top:      key.NewBinding(key.WithKeys("g", "home"), key.WithHelp("g", "top")),
 		Bottom:   key.NewBinding(key.WithKeys("G", "end"), key.WithHelp("G", "bottom")),
+		HScroll:  key.NewBinding(key.WithKeys("left", "right"), key.WithHelp("←/→", "scroll columns")),
 
 		Enter:      key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "config")),
 		Describe:   key.NewBinding(key.WithKeys("d"), key.WithHelp("d", "describe")),
@@ -101,7 +103,7 @@ type helpGroup struct {
 
 func (k keyMap) groups() []helpGroup {
 	return []helpGroup{
-		{"Navigation", []key.Binding{k.Up, k.Down, k.HalfUp, k.HalfDown, k.PageUp, k.PageDown, k.Top, k.Bottom}},
+		{"Navigation", []key.Binding{k.Up, k.Down, k.HalfUp, k.HalfDown, k.PageUp, k.PageDown, k.Top, k.Bottom, k.HScroll}},
 		{"Actions", []key.Binding{k.Enter, k.Describe, k.YAML, k.Logs, k.DeployLogs, k.Edit, k.Shell, k.Restart, k.Trigger, k.Delete, k.Docs}},
 		{"Views", []key.Binding{k.Focus, k.Jump, k.Palette, k.Filter, k.Sort, k.Refresh, k.Wide, k.Command}},
 		{"Cluster", []key.Binding{k.Namespace, k.AllNS, k.Context}},

--- a/internal/ui/table_view.go
+++ b/internal/ui/table_view.go
@@ -28,7 +28,15 @@ type tableView struct {
 	allRows []k8s.Row    // unfiltered
 	rows    []k8s.Row    // currently displayed (filtered + sorted)
 	vis     []int        // visible column indices (parallel to widths)
-	widths  []int        // fitted widths for visible columns
+	widths  []int        // natural (capped/floored) widths for visible columns
+
+	// Horizontal scroll, used when the columns are wider than the viewport. The
+	// first column is frozen so rows stay identifiable; hoff is how many of the
+	// remaining columns are scrolled off the left edge.
+	overflow bool
+	hoff     int
+	maxHoff  int
+	frozenW  int // rendered width of the frozen first column when overflowing
 
 	filtering bool
 	filter    textinput.Model
@@ -76,7 +84,33 @@ func (v *tableView) setData(t *k8s.Table) {
 
 func (v *tableView) toggleWide() {
 	v.showWide = !v.showWide
+	v.hoff = 0 // the column set changed; start from the left
 	v.rebuild()
+}
+
+// resetHScroll returns the horizontal scroll to the leftmost column. Used when
+// switching resources, whose column sets differ.
+func (v *tableView) resetHScroll() { v.hoff = 0 }
+
+// scrollLeft/scrollRight move the horizontal column window by one column. They
+// report whether anything moved, so the caller can fall back to other behavior
+// (e.g. focusing the sidebar) when already at the edge.
+func (v *tableView) scrollLeft() bool {
+	if !v.overflow || v.hoff <= 0 {
+		return false
+	}
+	v.hoff--
+	v.rebuild()
+	return true
+}
+
+func (v *tableView) scrollRight() bool {
+	if !v.overflow || v.hoff >= v.maxHoff {
+		return false
+	}
+	v.hoff++
+	v.rebuild()
+	return true
 }
 
 func (v *tableView) startFilter() {
@@ -185,7 +219,7 @@ func (v *tableView) rebuild() {
 		}
 	}
 
-	v.widths = v.fitWidths(v.vis)
+	v.computeLayout()
 
 	if v.cursor >= len(v.rows) {
 		v.cursor = len(v.rows) - 1
@@ -196,8 +230,13 @@ func (v *tableView) rebuild() {
 	v.ensureVisible()
 }
 
-func (v *tableView) fitWidths(vis []int) []int {
-	widths := make([]int, len(vis))
+// computeLayout sizes each visible column to its natural (content) width and
+// decides whether the row is wider than the viewport. When it overflows, the
+// first column is frozen and the rest become horizontally scrollable; otherwise
+// every column is shown. It clamps the scroll offset to the valid range.
+func (v *tableView) computeLayout() {
+	vis := v.vis
+	v.widths = make([]int, len(vis))
 	for n, ci := range vis {
 		w := len(v.cols[ci].Name)
 		if ci == v.sortCol {
@@ -218,49 +257,79 @@ func (v *tableView) fitWidths(vis []int) []int {
 		if w < floor {
 			w = floor
 		}
-		widths[n] = w
+		v.widths[n] = w
 	}
 
-	// Budget excludes the 2 cells of horizontal padding per column.
-	budget := v.width - 2*len(vis)
-	if budget < len(vis) {
-		return widths
+	// cellW counts a column's two padding cells alongside its content width.
+	cellW := func(n int) int { return v.widths[n] + 2 }
+
+	total := 0
+	for n := range vis {
+		total += cellW(n)
 	}
-	for sum(widths) > budget {
-		// Shrink the widest column above its floor; protect the name column.
-		target, best := -1, -1
-		for n, ci := range vis {
-			floor := colFloor
-			isName := strings.EqualFold(v.cols[ci].Name, "name")
-			if isName {
-				floor = nameFloor
-			}
-			if widths[n] <= floor {
-				continue
-			}
-			weight := widths[n]
-			if isName {
-				weight -= 1000
-			}
-			if weight > best {
-				best = weight
-				target = n
-			}
-		}
-		if target < 0 {
+	v.overflow = len(vis) > 1 && total > v.width
+	if !v.overflow {
+		v.hoff, v.maxHoff, v.frozenW = 0, 0, 0
+		return
+	}
+
+	// Freeze the first column, but cap it so at least part of one scrolling
+	// column always has room (a very long name shouldn't eat the whole row).
+	v.frozenW = v.widths[0]
+	if cap := v.width/2 - 2; v.frozenW > cap && cap >= nameFloor {
+		v.frozenW = cap
+	}
+	avail := v.width - (v.frozenW + 2)
+
+	// maxHoff is the smallest offset that still lets the last column fit: walk
+	// the scrollable columns from the right, accumulating until they overflow.
+	minStart := len(vis)
+	used := 0
+	for n := len(vis) - 1; n >= 1; n-- {
+		used += cellW(n)
+		if used > avail {
 			break
 		}
-		widths[target]--
+		minStart = n
 	}
-	return widths
+	v.maxHoff = minStart - 1
+	if v.maxHoff < 0 {
+		v.maxHoff = 0
+	}
+	v.hoff = clamp(v.hoff, 0, v.maxHoff)
 }
 
-func sum(xs []int) int {
-	t := 0
-	for _, x := range xs {
-		t += x
+// colSlot is one column to render: its index into vis and its rendered width.
+type colSlot struct {
+	n     int
+	width int
+}
+
+// renderPlan lists the columns to draw left-to-right for the current scroll
+// position. Without overflow that is simply every visible column; with overflow
+// it is the frozen first column followed by as many scrolling columns as fit.
+func (v tableView) renderPlan() []colSlot {
+	if len(v.vis) == 0 {
+		return nil
 	}
-	return t
+	if !v.overflow {
+		plan := make([]colSlot, len(v.vis))
+		for n := range v.vis {
+			plan[n] = colSlot{n: n, width: v.widths[n]}
+		}
+		return plan
+	}
+	plan := []colSlot{{n: 0, width: v.frozenW}}
+	used := v.frozenW + 2
+	for n := 1 + v.hoff; n < len(v.vis); n++ {
+		w := v.widths[n] + 2
+		if used+w > v.width && len(plan) > 1 {
+			break
+		}
+		plan = append(plan, colSlot{n: n, width: v.widths[n]})
+		used += w
+	}
+	return plan
 }
 
 // --- navigation -------------------------------------------------------------
@@ -307,10 +376,10 @@ func (v *tableView) colAt(x int) (int, bool) {
 		return 0, false
 	}
 	pos := 0
-	for n, ci := range v.vis {
-		w := v.widths[n] + 2 // one leading and one trailing cell of padding
+	for _, cs := range v.renderPlan() {
+		w := cs.width + 2 // one leading and one trailing cell of padding
 		if x >= pos && x < pos+w {
-			return ci, true
+			return v.vis[cs.n], true
 		}
 		pos += w
 	}
@@ -384,8 +453,10 @@ func (v tableView) View() string {
 }
 
 func (v tableView) headerLine() string {
+	plan := v.renderPlan()
 	var b strings.Builder
-	for n, ci := range v.vis {
+	for slot, cs := range plan {
+		ci := v.vis[cs.n]
 		title := strings.ToUpper(v.cols[ci].Name)
 		if ci == v.sortCol {
 			if v.sortDesc {
@@ -394,16 +465,27 @@ func (v tableView) headerLine() string {
 				title += " ▲"
 			}
 		}
-		b.WriteString(" " + v.th.HeaderVal.Render(cellFit(title, v.widths[n])) + " ")
+		// Arrow hints mark that columns are scrolled off either edge.
+		if v.overflow {
+			if slot == 0 && v.hoff > 0 {
+				title = "‹" + title
+			}
+			if slot == len(plan)-1 && cs.n < len(v.vis)-1 {
+				title = strings.TrimRight(cellFit(title, cs.width-1), " ") + "›"
+			}
+		}
+		b.WriteString(" " + v.th.HeaderVal.Render(cellFit(title, cs.width)) + " ")
 	}
 	return b.String()
 }
 
 func (v tableView) renderRow(row k8s.Row, selected bool) string {
+	plan := v.renderPlan()
 	var b strings.Builder
-	for n, ci := range v.vis {
+	for _, cs := range plan {
+		ci := v.vis[cs.n]
 		val := cell(row.Cells, ci)
-		txt := cellFit(val, v.widths[n])
+		txt := cellFit(val, cs.width)
 		if selected {
 			b.WriteString(" " + txt + " ") // colored later via the whole-row highlight
 		} else {

--- a/internal/ui/table_view.go
+++ b/internal/ui/table_view.go
@@ -100,7 +100,6 @@ func (v *tableView) scrollLeft() bool {
 		return false
 	}
 	v.hoff--
-	v.rebuild()
 	return true
 }
 
@@ -109,7 +108,6 @@ func (v *tableView) scrollRight() bool {
 		return false
 	}
 	v.hoff++
-	v.rebuild()
 	return true
 }
 

--- a/internal/ui/table_view_test.go
+++ b/internal/ui/table_view_test.go
@@ -1,0 +1,109 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bjarneo/kli/internal/k8s"
+)
+
+func scrollTable() *k8s.Table {
+	return &k8s.Table{
+		Columns: []k8s.Column{
+			{Name: "NAME"}, {Name: "READY"}, {Name: "STATUS"},
+			{Name: "RESTARTS"}, {Name: "AGE"}, {Name: "CPU"}, {Name: "MEM"},
+		},
+		Rows: []k8s.Row{
+			{Name: "alpha", Cells: []string{"alpha-pod-with-a-fairly-long-name", "1/1", "Running", "0", "5d", "12m", "40Mi"}},
+			{Name: "beta", Cells: []string{"beta-pod", "1/1", "Running", "3", "2h", "5m", "10Mi"}},
+		},
+	}
+}
+
+// planCols returns the set of underlying column indices the render plan covers.
+func planCols(v *tableView) map[int]bool {
+	got := map[int]bool{}
+	for _, cs := range v.renderPlan() {
+		got[v.vis[cs.n]] = true
+	}
+	return got
+}
+
+func TestTableNoOverflowShowsAllColumns(t *testing.T) {
+	v := newTableView(PickTheme("ansi"))
+	v.setData(scrollTable())
+	v.setSize(400, 20) // plenty of room
+
+	if v.overflow {
+		t.Fatalf("wide viewport should not overflow")
+	}
+	if got := planCols(&v); len(got) != len(v.cols) {
+		t.Fatalf("expected all %d columns rendered, got %d", len(v.cols), len(got))
+	}
+}
+
+func TestTableOverflowFreezesFirstAndScrollsToLast(t *testing.T) {
+	v := newTableView(PickTheme("ansi"))
+	v.setData(scrollTable())
+	v.setSize(40, 20) // narrow: columns cannot all fit
+
+	if !v.overflow {
+		t.Fatalf("narrow viewport should overflow")
+	}
+	if v.maxHoff <= 0 {
+		t.Fatalf("expected a positive maxHoff when overflowing, got %d", v.maxHoff)
+	}
+	if !planCols(&v)[0] {
+		t.Fatalf("frozen first column missing at hoff=0")
+	}
+
+	// Scrolling right must eventually reveal the last column, then stop there.
+	last := len(v.cols) - 1
+	for i := 0; i < len(v.cols)+2; i++ {
+		if planCols(&v)[last] {
+			break
+		}
+		if !v.scrollRight() && !planCols(&v)[last] {
+			t.Fatalf("hit the right edge but the last column never appeared")
+		}
+	}
+	if !planCols(&v)[0] {
+		t.Fatalf("first column should stay frozen after scrolling")
+	}
+	if !planCols(&v)[last] {
+		t.Fatalf("last column unreachable by scrolling")
+	}
+	if v.scrollRight() {
+		t.Fatalf("scrollRight past maxHoff should report no movement")
+	}
+	if !v.scrollLeft() {
+		t.Fatalf("scrollLeft from the right edge should move")
+	}
+}
+
+func TestTableScrollLeftStopsAtEdgeAndHints(t *testing.T) {
+	v := newTableView(PickTheme("ansi"))
+	v.setData(scrollTable())
+	v.setSize(40, 20)
+
+	for v.scrollLeft() { // unwind to the leftmost column
+	}
+	if v.hoff != 0 {
+		t.Fatalf("expected hoff 0 at left edge, got %d", v.hoff)
+	}
+	if v.scrollLeft() {
+		t.Fatalf("scrollLeft at the left edge should report no movement")
+	}
+	if !strings.Contains(v.headerLine(), "›") {
+		t.Fatalf("expected a right-scroll hint in the header:\n%s", v.headerLine())
+	}
+}
+
+func TestTableScrollNoopWithoutOverflow(t *testing.T) {
+	v := newTableView(PickTheme("ansi"))
+	v.setData(scrollTable())
+	v.setSize(400, 20)
+	if v.scrollLeft() || v.scrollRight() {
+		t.Fatalf("scrolling should be inert when the table fits")
+	}
+}


### PR DESCRIPTION


https://github.com/user-attachments/assets/05c27b0f-4ee1-4425-8737-2ffd01c3bcf0

On narrow terminals the table can't fit every column, so the rightmost ones (AGE, CPU, MEM, …) get truncated or pushed off-screen with no way to reach them.

Columns now keep their natural width. When they overflow the viewport the first column stays frozen (rows remain identifiable) and the rest scroll with the **← / →** arrow keys. The header shows **‹ / ›** when columns are hidden off either edge.

`h` and `l` keep their current meanings (focus sidebar / logs) — only the arrows scroll. Scrolling resets when switching resources or toggling wide columns, and is a no-op when everything already fits.
