### PR TITLE
feat: add as, as-group and as-uid as available arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ ku --resource deploy     # start on a resource type
 ku --theme tokyonight    # switch theme
 ku --edit                # start in edit mode (default is read-only)
 ku --dev                 # developer view, app resources only
+ku --as system:admin     # act as another identity
 ku upgrade               # replace the current binary with the latest release
 ```
 
@@ -88,6 +89,25 @@ ku --dev --edit          # edit mode, developer view
 
 Disabled keys are dropped from the footer hints and the command palette, and `?`
 summarizes the active mode.
+
+## Impersonation
+
+`--as`, `--as-group` and `--as-uid` work like their kubectl counterparts. Every
+call in the session acts as that identity, which is the way to reach objects
+your own kubeconfig user may not touch.
+
+```
+ku --edit --as system:admin
+ku --edit --as system:admin --as-group system:masters
+```
+
+`--as-group` is repeatable. Groups and a uid need a user, so `--as-group` on its
+own is rejected before the session starts.
+
+The header shows an `as` chip while impersonation is active, and `?` names the
+identity in full. Impersonation is per-invocation: it is never written to
+`state.json`, so the next launch is back to your own identity. It also does not
+relax the read-only default, so writes still need `--edit` or `Shift+E`.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -104,8 +104,8 @@ ku --edit --as system:admin --as-group system:masters
 `--as-group` is repeatable. Groups and a uid need a user, so `--as-group` on its
 own is rejected before the session starts.
 
-The header shows an `as` chip while impersonation is active, and `?` names the
-identity in full. Impersonation is per-invocation: it is never written to
+The header shows an `as` chip while impersonation is active. Impersonation is
+per-invocation: it is never written to
 `state.json`, so the next launch is back to your own identity. It also does not
 relax the read-only default, so writes still need `--edit` or `Shift+E`.
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -163,3 +163,30 @@ relevant actions are always in view.
 Switching context rebuilds the client, the resource catalog, and the left nav.
 Your last context and namespace are remembered in `~/.config/ku/state.json` for
 next launch.
+
+## Impersonation
+
+`--as`, `--as-group` and `--as-uid` make every call in the session act as
+another identity, the same as the kubectl flags of those names. Use it to reach
+objects your own kubeconfig user may not touch, for example deleting something
+only a cluster admin may delete.
+
+```
+ku --edit --as system:admin --as-group system:masters
+```
+
+`--as-group` is repeatable. A group or a uid without a user is rejected before
+the session starts, with a message naming the flag, rather than surfacing later
+as a kubeconfig load error.
+
+While impersonation is active the header carries an `as` chip, showing the user
+name and a group count, and `?` names the identity in full. The `C` command
+preview includes the flags, so the printed `kubectl` line reproduces what the
+session is doing.
+
+The identity survives a context switch with `c`, since the rebuilt client keeps
+it. It is never persisted: `state.json` holds only context, namespace and theme,
+so the next launch runs as you again.
+
+Impersonation changes who you are, not what edit mode allows. The session is
+still read-only unless you pass `--edit` or press `Shift+E`.

--- a/docs/features.md
+++ b/docs/features.md
@@ -180,9 +180,8 @@ the session starts, with a message naming the flag, rather than surfacing later
 as a kubeconfig load error.
 
 While impersonation is active the header carries an `as` chip, showing the user
-name and a group count, and `?` names the identity in full. The `C` command
-preview includes the flags, so the printed `kubectl` line reproduces what the
-session is doing.
+name and a group count. The `C` command preview includes the flags, so the
+printed `kubectl` line reproduces what the session is doing.
 
 The identity survives a context switch with `c`, since the rebuilt client keeps
 it. It is never persisted: `state.json` holds only context, namespace and theme,

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -33,6 +33,7 @@ ku -n kube-system        # start in a namespace
 ku --resource deploy     # start on a resource type
 ku --theme tokyonight    # use the Tokyo Night theme
 ku --check               # read-only connectivity check, no UI
+ku --edit --as system:admin   # act as another identity
 ku --version
 ```
 
@@ -55,6 +56,11 @@ ku --version
 | `-n`, `--namespace` | initial namespace; omit to use the remembered or context namespace |
 | `--resource` | initial resource, e.g. `pods`, `deploy`, `svc` |
 | `--theme` | `ansi` (default) or a built-in theme, e.g. `dracula`, `gruvbox`, `catppuccin` (see Themes) |
+| `--as` | username to impersonate for the session, e.g. `system:admin` |
+| `--as-group` | group to impersonate; repeat the flag for multiple groups |
+| `--as-uid` | uid to impersonate |
+| `--dev` | developer view: hide cluster admin resources and node ops |
+| `--edit` | start in edit mode; the default is read-only |
 | `--check` | run a read-only connectivity check and exit |
 | `--version` | print version and exit |
 
@@ -97,6 +103,12 @@ ku reads optional sidebar config from `~/.config/ku/config.yaml`. Use
 
 See [Configuration](configuration.md) for file paths, sidebar examples,
 resource names, and opt-in resources.
+
+## Impersonation
+
+`--as`, `--as-group` and `--as-uid` work like their kubectl counterparts: every
+call in the session acts as that identity. See [Features](features.md) for
+details.
 
 ## Session memory
 

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -42,9 +42,10 @@ type Client struct {
 // NewClient builds a client from the kubeconfig. kubeconfigPath, if non-empty,
 // overrides the default lookup ($KUBECONFIG, then ~/.kube/config). If
 // contextOverride is non-empty it selects that context instead of the
-// kubeconfig's current-context.
-func NewClient(contextOverride, kubeconfigPath string) (*Client, error) {
-	cc, restCfg, err := loadClientConfig(contextOverride, kubeconfigPath)
+// kubeconfig's current-context. A non-zero imp makes every call act as that
+// identity.
+func NewClient(contextOverride, kubeconfigPath string, imp Impersonation) (*Client, error) {
+	cc, restCfg, err := loadClientConfig(contextOverride, kubeconfigPath, imp)
 	if err != nil {
 		return nil, err
 	}
@@ -116,12 +117,12 @@ func NewClient(contextOverride, kubeconfigPath string) (*Client, error) {
 
 // ValidateKubeconfig checks local kubeconfig loading without connecting to the
 // API server. It lets startup fail before the terminal UI sends feature probes.
-func ValidateKubeconfig(contextOverride, kubeconfigPath string) error {
-	_, _, err := loadClientConfig(contextOverride, kubeconfigPath)
+func ValidateKubeconfig(contextOverride, kubeconfigPath string, imp Impersonation) error {
+	_, _, err := loadClientConfig(contextOverride, kubeconfigPath, imp)
 	return err
 }
 
-func loadClientConfig(contextOverride, kubeconfigPath string) (clientcmd.ClientConfig, *rest.Config, error) {
+func loadClientConfig(contextOverride, kubeconfigPath string, imp Impersonation) (clientcmd.ClientConfig, *rest.Config, error) {
 	rules := clientcmd.NewDefaultClientConfigLoadingRules()
 	if kubeconfigPath != "" {
 		rules.ExplicitPath = kubeconfigPath
@@ -129,6 +130,14 @@ func loadClientConfig(contextOverride, kubeconfigPath string) (clientcmd.ClientC
 	overrides := &clientcmd.ConfigOverrides{}
 	if contextOverride != "" {
 		overrides.CurrentContext = contextOverride
+	}
+	// The same overrides kubectl binds --as, --as-group and --as-uid to. They
+	// become restCfg.Impersonate, which every client and transport built below
+	// inherits, so no call site needs to know about impersonation.
+	if imp.Active() {
+		overrides.AuthInfo.Impersonate = imp.User
+		overrides.AuthInfo.ImpersonateGroups = imp.Groups
+		overrides.AuthInfo.ImpersonateUID = imp.UID
 	}
 	cc := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(rules, overrides)
 

--- a/internal/k8s/client_test.go
+++ b/internal/k8s/client_test.go
@@ -13,7 +13,7 @@ func TestValidateKubeconfigEmptyConfigError(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err := ValidateKubeconfig("", path)
+	err := ValidateKubeconfig("", path, Impersonation{})
 	if err == nil {
 		t.Fatal("ValidateKubeconfig succeeded for empty config")
 	}

--- a/internal/k8s/impersonate.go
+++ b/internal/k8s/impersonate.go
@@ -1,0 +1,59 @@
+package k8s
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// Impersonation is the identity to act as for the whole session, mirroring
+// kubectl's --as, --as-group and --as-uid. The zero value means "use the
+// identity the kubeconfig context resolves to".
+type Impersonation struct {
+	// User is the username to act as, e.g. "system:admin".
+	User string
+	// Groups are the groups to act as. kubectl allows repeating --as-group, so
+	// this is a list.
+	Groups []string
+	// UID is the uid to act as. Rarely needed; the API server matches it against
+	// the impersonated user.
+	UID string
+}
+
+// Active reports whether any impersonation was requested.
+func (i Impersonation) Active() bool {
+	return i.User != "" || len(i.Groups) > 0 || i.UID != ""
+}
+
+// Validate rejects groups or a uid without a user. clientcmd refuses to load a
+// kubeconfig with that combination anyway ("requesting uid, groups or user-extra
+// ... without impersonating a user"); catching it here reports the flag the user
+// actually typed instead of a config error from deeper in the stack.
+func (i Impersonation) Validate() error {
+	if i.User != "" {
+		return nil
+	}
+	switch {
+	case len(i.Groups) > 0:
+		return errors.New("--as-group requires --as")
+	case i.UID != "":
+		return errors.New("--as-uid requires --as")
+	}
+	return nil
+}
+
+// String renders the identity for the connectivity check and error messages.
+// It returns "" when no impersonation is active.
+func (i Impersonation) String() string {
+	if !i.Active() {
+		return ""
+	}
+	s := i.User
+	if i.UID != "" {
+		s += fmt.Sprintf(" (uid %s)", i.UID)
+	}
+	if len(i.Groups) > 0 {
+		s += " (groups: " + strings.Join(i.Groups, ", ") + ")"
+	}
+	return s
+}

--- a/internal/k8s/impersonate_test.go
+++ b/internal/k8s/impersonate_test.go
@@ -1,0 +1,168 @@
+package k8s
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestImpersonationActive(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		imp  Impersonation
+		want bool
+	}{
+		{"zero", Impersonation{}, false},
+		{"user", Impersonation{User: "system:admin"}, true},
+		{"groups only", Impersonation{Groups: []string{"system:masters"}}, true},
+		{"uid only", Impersonation{UID: "abc"}, true},
+	} {
+		if got := tc.imp.Active(); got != tc.want {
+			t.Errorf("%s: Active() = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestImpersonationValidate(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		imp     Impersonation
+		wantErr string
+	}{
+		{"zero", Impersonation{}, ""},
+		{"user only", Impersonation{User: "system:admin"}, ""},
+		{"user and groups", Impersonation{User: "u", Groups: []string{"g"}}, ""},
+		{"user and uid", Impersonation{User: "u", UID: "1"}, ""},
+		{"groups without user", Impersonation{Groups: []string{"system:masters"}}, "--as-group requires --as"},
+		{"uid without user", Impersonation{UID: "1"}, "--as-uid requires --as"},
+	} {
+		err := tc.imp.Validate()
+		switch {
+		case tc.wantErr == "" && err != nil:
+			t.Errorf("%s: Validate() = %v, want nil", tc.name, err)
+		case tc.wantErr != "" && err == nil:
+			t.Errorf("%s: Validate() = nil, want %q", tc.name, tc.wantErr)
+		case tc.wantErr != "" && err != nil && err.Error() != tc.wantErr:
+			t.Errorf("%s: Validate() = %q, want %q", tc.name, err, tc.wantErr)
+		}
+	}
+}
+
+func TestImpersonationString(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		imp  Impersonation
+		want string
+	}{
+		{"zero", Impersonation{}, ""},
+		{"user", Impersonation{User: "system:admin"}, "system:admin"},
+		{"user and groups", Impersonation{User: "u", Groups: []string{"a", "b"}}, "u (groups: a, b)"},
+		{"user and uid", Impersonation{User: "u", UID: "42"}, "u (uid 42)"},
+	} {
+		if got := tc.imp.String(); got != tc.want {
+			t.Errorf("%s: String() = %q, want %q", tc.name, got, tc.want)
+		}
+	}
+}
+
+// writeKubeconfig writes a minimal kubeconfig that resolves without contacting
+// a cluster, so the config plumbing can be tested offline.
+func writeKubeconfig(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "config")
+	body := `apiVersion: v1
+kind: Config
+current-context: test
+clusters:
+- name: test
+  cluster:
+    server: https://127.0.0.1:6443
+contexts:
+- name: test
+  context:
+    cluster: test
+    user: test
+    namespace: demo
+users:
+- name: test
+  user:
+    token: abc
+`
+	if err := os.WriteFile(path, []byte(body), 0600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// The impersonation must land on the rest.Config, because every client and
+// transport in this package is built from it.
+func TestLoadClientConfigAppliesImpersonation(t *testing.T) {
+	path := writeKubeconfig(t)
+
+	// Compared field by field: clientcmd fills Extra with an empty map, so
+	// DeepEqual against a literal would fail on nil versus empty.
+	for _, tc := range []struct {
+		name       string
+		imp        Impersonation
+		wantUser   string
+		wantUID    string
+		wantGroups []string
+	}{
+		{name: "none"},
+		{name: "user", imp: Impersonation{User: "system:admin"}, wantUser: "system:admin"},
+		{
+			name:       "user groups and uid",
+			imp:        Impersonation{User: "system:admin", Groups: []string{"system:masters", "devs"}, UID: "42"},
+			wantUser:   "system:admin",
+			wantUID:    "42",
+			wantGroups: []string{"system:masters", "devs"},
+		},
+	} {
+		_, cfg, err := loadClientConfig("", path, tc.imp)
+		if err != nil {
+			t.Fatalf("%s: loadClientConfig: %v", tc.name, err)
+		}
+		if cfg.Impersonate.UserName != tc.wantUser {
+			t.Errorf("%s: UserName = %q, want %q", tc.name, cfg.Impersonate.UserName, tc.wantUser)
+		}
+		if cfg.Impersonate.UID != tc.wantUID {
+			t.Errorf("%s: UID = %q, want %q", tc.name, cfg.Impersonate.UID, tc.wantUID)
+		}
+		if got := strings.Join(cfg.Impersonate.Groups, ","); got != strings.Join(tc.wantGroups, ",") {
+			t.Errorf("%s: Groups = %q, want %q", tc.name, got, tc.wantGroups)
+		}
+	}
+}
+
+// A context override and impersonation are independent overrides; setting one
+// must not drop the other.
+func TestLoadClientConfigImpersonationWithContextOverride(t *testing.T) {
+	path := writeKubeconfig(t)
+
+	cc, cfg, err := loadClientConfig("test", path, Impersonation{User: "system:admin"})
+	if err != nil {
+		t.Fatalf("loadClientConfig: %v", err)
+	}
+	if cfg.Impersonate.UserName != "system:admin" {
+		t.Errorf("Impersonate.UserName = %q, want system:admin", cfg.Impersonate.UserName)
+	}
+	ns, _, err := cc.Namespace()
+	if err != nil {
+		t.Fatalf("Namespace: %v", err)
+	}
+	if ns != "demo" {
+		t.Errorf("namespace = %q, want demo (context override lost)", ns)
+	}
+}
+
+func TestNewClientRejectsBadKubeconfigWithImpersonation(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config")
+	if err := os.WriteFile(path, nil, 0600); err != nil {
+		t.Fatal(err)
+	}
+	err := ValidateKubeconfig("", path, Impersonation{User: "system:admin"})
+	if err == nil || !strings.Contains(err.Error(), "kubeconfig is empty or missing") {
+		t.Fatalf("error = %v, want the friendly kubeconfig message", err)
+	}
+}

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -2737,24 +2737,18 @@ func (a App) modeChip() string {
 	return a.theme.StatusErr.Render("● EDIT")
 }
 
-// modeNote is a one-line summary of the active mode and identity for the help
-// screen. It is empty in the default full read/write mode with no
-// impersonation, which needs no callout.
+// modeNote is a one-line summary of the active mode for the help screen. It is
+// empty in the default full read/write mode, which needs no callout.
 func (a App) modeNote() string {
-	mode := ""
 	switch {
 	case a.dev && a.readOnly:
-		mode = "Developer + read-only mode: nav scoped to app resources; all writes disabled"
+		return "Developer + read-only mode: nav scoped to app resources; all writes disabled"
 	case a.dev:
-		mode = "Developer mode: nav scoped to app resources; node ops disabled"
+		return "Developer mode: nav scoped to app resources; node ops disabled"
 	case a.readOnly:
-		mode = "Read-only mode: writes are disabled. Fat-fingers, your cluster is safe."
+		return "Read-only mode: writes are disabled. Fat-fingers, your cluster is safe."
 	}
-	imp := ""
-	if a.impersonate.Active() {
-		imp = "Impersonating " + a.impersonate.String()
-	}
-	return strings.Join(nonEmpty([]string{imp, mode}), " · ")
+	return ""
 }
 
 type hint struct{ key, desc string }

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -149,6 +149,11 @@ type App struct {
 	// runtime from the command palette.
 	dev      bool
 	readOnly bool
+
+	// impersonate is the identity every cluster call acts as, from
+	// --as/--as-group/--as-uid. Set once at startup and never persisted; it
+	// changes who you are, not what edit mode allows.
+	impersonate k8s.Impersonation
 }
 
 func newSpinner(th Theme) spinner.Model {
@@ -2365,7 +2370,7 @@ func (a App) applySelection(res selResult) (tea.Model, tea.Cmd) {
 		}
 		a.lookupSeq++
 		a.setStatus("switching context…", false)
-		return a, switchContextCmd(res.id, a.client.Kubeconfig())
+		return a, switchContextCmd(res.id, a.client.Kubeconfig(), a.impersonate)
 	case selContainer:
 		return a.startLogs(a.logTarget.ns, a.logTarget.name, res.id, a.logPrevious[res.id])
 	case selExecContainer:
@@ -2665,6 +2670,11 @@ func (a App) headerView() string {
 	if a.dev {
 		chips = append(chips, chip("mode", "dev"))
 	}
+	// Warn-styled rather than a plain chip: every call in the session runs as
+	// someone else, which should never be easy to miss.
+	if a.impersonate.Active() {
+		chips = append(chips, th.HeaderKey.Render("as ")+th.Warn.Render(truncate(impersonationLabel(a.impersonate), 28)))
+	}
 	if n := len(a.portForwards); n > 0 {
 		chips = append(chips, chip("pf", itoa(n)))
 	}
@@ -2691,9 +2701,13 @@ func (a App) headerView() string {
 
 	avail := a.width - lipgloss.Width(right) - 2
 	left := logo
+	// Skip a chip that does not fit instead of stopping at it. The chips at the
+	// end (node scope, active filter) are the ones that keep a narrowed list from
+	// looking like the whole set, so a wide chip ahead of them must not take them
+	// down with it.
 	for _, c := range chips {
 		if lipgloss.Width(left)+2+lipgloss.Width(c) > avail {
-			break
+			continue
 		}
 		left += "  " + c
 	}
@@ -2723,18 +2737,24 @@ func (a App) modeChip() string {
 	return a.theme.StatusErr.Render("● EDIT")
 }
 
-// modeNote is a one-line summary of the active mode for the help screen. It is
-// empty in the default full read/write mode, which needs no callout.
+// modeNote is a one-line summary of the active mode and identity for the help
+// screen. It is empty in the default full read/write mode with no
+// impersonation, which needs no callout.
 func (a App) modeNote() string {
+	mode := ""
 	switch {
 	case a.dev && a.readOnly:
-		return "Developer + read-only mode: nav scoped to app resources; all writes disabled"
+		mode = "Developer + read-only mode: nav scoped to app resources; all writes disabled"
 	case a.dev:
-		return "Developer mode: nav scoped to app resources; node ops disabled"
+		mode = "Developer mode: nav scoped to app resources; node ops disabled"
 	case a.readOnly:
-		return "Read-only mode: writes are disabled. Fat-fingers, your cluster is safe."
+		mode = "Read-only mode: writes are disabled. Fat-fingers, your cluster is safe."
 	}
-	return ""
+	imp := ""
+	if a.impersonate.Active() {
+		imp = "Impersonating " + a.impersonate.String()
+	}
+	return strings.Join(nonEmpty([]string{imp, mode}), " · ")
 }
 
 type hint struct{ key, desc string }

--- a/internal/ui/command_view.go
+++ b/internal/ui/command_view.go
@@ -95,6 +95,18 @@ func (a App) kubectlBaseArgs() []string {
 	if contextName := a.client.ContextName; contextName != "" {
 		args = append(args, "--context", contextName)
 	}
+	// Without these the printed command would run as a different identity than
+	// the session it claims to reproduce. kubectl rejects --as-group and --as-uid
+	// without --as, so they only go out alongside it.
+	if a.impersonate.User != "" {
+		args = append(args, "--as", a.impersonate.User)
+		for _, g := range a.impersonate.Groups {
+			args = append(args, "--as-group", g)
+		}
+		if a.impersonate.UID != "" {
+			args = append(args, "--as-uid", a.impersonate.UID)
+		}
+	}
 	return args
 }
 

--- a/internal/ui/command_view_test.go
+++ b/internal/ui/command_view_test.go
@@ -93,3 +93,59 @@ func TestShellJoinQuotesUnsafeArgs(t *testing.T) {
 		t.Fatalf("shellJoin() = %q; want quoted context", got)
 	}
 }
+
+func TestKubectlBaseArgsIncludesImpersonation(t *testing.T) {
+	app := App{
+		client: &k8s.Client{ContextName: "prod"},
+		impersonate: k8s.Impersonation{
+			User:   "system:admin",
+			Groups: []string{"system:masters", "platform devs"},
+			UID:    "42",
+		},
+		res: k8s.ResourceInfo{Resource: "pods", Namespaced: true},
+	}
+
+	got := app.kubectlGetTableCommand()
+	want := "kubectl --context prod --as system:admin --as-group system:masters " +
+		"--as-group 'platform devs' --as-uid 42 get pods --all-namespaces"
+	if got != want {
+		t.Fatalf("kubectlGetTableCommand() = %q; want %q", got, want)
+	}
+}
+
+// kubectl rejects --as-group and --as-uid without --as ("--as-uid must be used
+// with --as"), so a printed command must never carry them alone. Validate keeps
+// this out of a real session, but the App takes an Impersonation from callers
+// that do not run it.
+func TestKubectlBaseArgsOmitsGroupsAndUIDWithoutUser(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		imp  k8s.Impersonation
+	}{
+		{"groups only", k8s.Impersonation{Groups: []string{"system:masters"}}},
+		{"uid only", k8s.Impersonation{UID: "42"}},
+	} {
+		app := App{
+			client:      &k8s.Client{ContextName: "prod"},
+			res:         k8s.ResourceInfo{Resource: "pods", Namespaced: true},
+			impersonate: tc.imp,
+		}
+
+		got := app.kubectlGetTableCommand()
+		if strings.Contains(got, "--as") {
+			t.Errorf("%s: kubectlGetTableCommand() = %q; want no impersonation flags", tc.name, got)
+		}
+	}
+}
+
+func TestKubectlBaseArgsOmitsImpersonationWhenUnset(t *testing.T) {
+	app := App{
+		client: &k8s.Client{ContextName: "prod"},
+		res:    k8s.ResourceInfo{Resource: "pods", Namespaced: true},
+	}
+
+	got := app.kubectlGetTableCommand()
+	if strings.Contains(got, "--as") {
+		t.Fatalf("kubectlGetTableCommand() = %q; want no impersonation flags", got)
+	}
+}

--- a/internal/ui/help_view.go
+++ b/internal/ui/help_view.go
@@ -97,14 +97,22 @@ func (h helpView) View(width, height int) string {
 
 	border := h.th.ModalBorder
 	spacer := "\n\n"
-	frameRows := 6 // border/padding plus title and blank spacer
+	frameRows := 6     // border/padding plus title and blank spacer
+	inner := width - 6 // border plus Padding(1, 2)
 	if height < 7 {
 		border = border.Padding(0, 1)
 		spacer = "\n"
-		frameRows = 3 // border plus title line
+		frameRows = 3     // border plus title line
+		inner = width - 4 // border plus Padding(0, 1)
 	}
+	// The note carries the impersonated identity, which can be long. Wrap it to
+	// the inner width instead of letting it set the box width: a box wider than
+	// the terminal loses its right border and the identity itself to the overlay
+	// clamp, which is the one place the full identity is meant to be readable.
+	var noteLines []string
 	if h.note != "" {
-		frameRows++ // the mode summary takes one extra line
+		noteLines = wrapPlain(h.note, inner)
+		frameRows += len(noteLines)
 	}
 	visible := height - frameRows
 	if visible < 1 {
@@ -129,8 +137,8 @@ func (h helpView) View(width, height int) string {
 		hint = h.th.Dim.Render(fmt.Sprintf("  ↑↓ scroll %d/%d · esc close", h.offset+1, maxOffset+1))
 	}
 	header := title + hint
-	if h.note != "" {
-		header += "\n" + h.th.Warn.Render(h.note)
+	for _, line := range noteLines {
+		header += "\n" + h.th.Warn.Render(line)
 	}
 	content := header + spacer + grid
 

--- a/internal/ui/help_view.go
+++ b/internal/ui/help_view.go
@@ -105,10 +105,9 @@ func (h helpView) View(width, height int) string {
 		frameRows = 3     // border plus title line
 		inner = width - 4 // border plus Padding(0, 1)
 	}
-	// The note carries the impersonated identity, which can be long. Wrap it to
-	// the inner width instead of letting it set the box width: a box wider than
-	// the terminal loses its right border and the identity itself to the overlay
-	// clamp, which is the one place the full identity is meant to be readable.
+	// Wrap the note to the inner width instead of letting it set the box width:
+	// a box wider than the terminal loses its right border and the tail of the
+	// note to the overlay clamp.
 	var noteLines []string
 	if h.note != "" {
 		noteLines = wrapPlain(h.note, inner)

--- a/internal/ui/help_view_test.go
+++ b/internal/ui/help_view_test.go
@@ -1,0 +1,49 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+
+	"charm.land/lipgloss/v2"
+)
+
+// The mode note carries the impersonated identity, and the help overlay is the
+// one place it is meant to be readable in full. A note wider than the terminal
+// would set the box width and lose both the right border and the identity to
+// the overlay clamp.
+func TestHelpViewWrapsLongModeNote(t *testing.T) {
+	h := newHelpView(PickTheme("ansi"), defaultKeys())
+	h.note = "Impersonating system:serviceaccount:kube-system:cluster-admin (groups: system:masters) · Developer + read-only mode: nav scoped to app resources; all writes disabled"
+
+	for _, width := range []int{60, 80, 100, 132} {
+		got := ansi.Strip(h.View(width, 30))
+		if w := lipgloss.Width(got); w > width {
+			t.Errorf("width %d: View() rendered %d columns wide", width, w)
+		}
+		if !strings.Contains(got, "system:serviceaccount:kube-system:cluster-admin") {
+			t.Errorf("width %d: View() = %q, want the full impersonated identity", width, got)
+		}
+		if !strings.Contains(got, "all writes disabled") {
+			t.Errorf("width %d: View() lost the tail of the mode note", width)
+		}
+	}
+}
+
+// The note takes rows away from the keybinding grid, so a wrapped note has to
+// shrink the grid by its own line count or the box outgrows the overlay.
+func TestHelpViewNoteHeightAccountsForWrapping(t *testing.T) {
+	th := PickTheme("ansi")
+	keys := defaultKeys()
+	plain := newHelpView(th, keys)
+	wrapped := newHelpView(th, keys)
+	wrapped.note = "Impersonating system:admin (groups: system:masters) · Developer + read-only mode: nav scoped to app resources; all writes disabled"
+
+	const width, height = 80, 30
+	plainRows := strings.Count(plain.View(width, height), "\n")
+	wrappedRows := strings.Count(wrapped.View(width, height), "\n")
+	if wrappedRows != plainRows {
+		t.Fatalf("note changed the box height: %d rows with a note, %d without", wrappedRows, plainRows)
+	}
+}

--- a/internal/ui/help_view_test.go
+++ b/internal/ui/help_view_test.go
@@ -9,23 +9,23 @@ import (
 	"charm.land/lipgloss/v2"
 )
 
-// The mode note carries the impersonated identity, and the help overlay is the
-// one place it is meant to be readable in full. A note wider than the terminal
-// would set the box width and lose both the right border and the identity to
-// the overlay clamp.
+// A note wider than the terminal would set the box width, costing the modal its
+// right border and the note its tail to the overlay clamp.
 func TestHelpViewWrapsLongModeNote(t *testing.T) {
 	h := newHelpView(PickTheme("ansi"), defaultKeys())
-	h.note = "Impersonating system:serviceaccount:kube-system:cluster-admin (groups: system:masters) · Developer + read-only mode: nav scoped to app resources; all writes disabled"
+	h.note = "Developer + read-only mode: nav scoped to app resources; all writes disabled"
 
 	for _, width := range []int{60, 80, 100, 132} {
 		got := ansi.Strip(h.View(width, 30))
 		if w := lipgloss.Width(got); w > width {
 			t.Errorf("width %d: View() rendered %d columns wide", width, w)
 		}
-		if !strings.Contains(got, "system:serviceaccount:kube-system:cluster-admin") {
-			t.Errorf("width %d: View() = %q, want the full impersonated identity", width, got)
+		if !strings.Contains(got, "Developer + read-only mode") {
+			t.Errorf("width %d: View() = %q, want the mode note", width, got)
 		}
-		if !strings.Contains(got, "all writes disabled") {
+		// The note wraps, so check the last word rather than a phrase that a
+		// line break can split.
+		if !strings.Contains(got, "disabled") {
 			t.Errorf("width %d: View() lost the tail of the mode note", width)
 		}
 	}
@@ -38,7 +38,7 @@ func TestHelpViewNoteHeightAccountsForWrapping(t *testing.T) {
 	keys := defaultKeys()
 	plain := newHelpView(th, keys)
 	wrapped := newHelpView(th, keys)
-	wrapped.note = "Impersonating system:admin (groups: system:masters) · Developer + read-only mode: nav scoped to app resources; all writes disabled"
+	wrapped.note = "Developer + read-only mode: nav scoped to app resources; all writes disabled"
 
 	const width, height = 80, 30
 	plainRows := strings.Count(plain.View(width, height), "\n")

--- a/internal/ui/impersonate_test.go
+++ b/internal/ui/impersonate_test.go
@@ -59,22 +59,18 @@ func TestHeaderOmitsImpersonationChipWhenUnset(t *testing.T) {
 	}
 }
 
-func TestModeNoteCombinesImpersonationAndMode(t *testing.T) {
+// The help overlay is a keybinding reference, so the identity stays out of it.
+// The header chip and the `C` command preview are where it shows.
+func TestModeNoteOmitsImpersonation(t *testing.T) {
 	for _, tc := range []struct {
-		name     string
-		app      App
-		contains []string
-		empty    bool
+		name string
+		app  App
+		want string
 	}{
 		{
-			name:  "no mode and no impersonation",
-			app:   App{},
-			empty: true,
-		},
-		{
-			name:     "impersonation only",
-			app:      App{impersonate: k8s.Impersonation{User: "system:admin"}},
-			contains: []string{"Impersonating system:admin"},
+			name: "impersonation only",
+			app:  App{impersonate: k8s.Impersonation{User: "system:admin"}},
+			want: "",
 		},
 		{
 			name: "impersonation and read-only",
@@ -82,25 +78,16 @@ func TestModeNoteCombinesImpersonationAndMode(t *testing.T) {
 				readOnly:    true,
 				impersonate: k8s.Impersonation{User: "system:admin", Groups: []string{"system:masters"}},
 			},
-			contains: []string{"Impersonating system:admin (groups: system:masters)", "·", "Read-only mode"},
+			want: "Read-only mode: writes are disabled. Fat-fingers, your cluster is safe.",
 		},
 		{
-			name:     "read-only only",
-			app:      App{readOnly: true},
-			contains: []string{"Read-only mode"},
+			name: "no mode and no impersonation",
+			app:  App{},
+			want: "",
 		},
 	} {
-		got := tc.app.modeNote()
-		if tc.empty {
-			if got != "" {
-				t.Errorf("%s: modeNote() = %q, want empty", tc.name, got)
-			}
-			continue
-		}
-		for _, want := range tc.contains {
-			if !strings.Contains(got, want) {
-				t.Errorf("%s: modeNote() = %q, want it to contain %q", tc.name, got, want)
-			}
+		if got := tc.app.modeNote(); got != tc.want {
+			t.Errorf("%s: modeNote() = %q, want %q", tc.name, got, tc.want)
 		}
 	}
 }

--- a/internal/ui/impersonate_test.go
+++ b/internal/ui/impersonate_test.go
@@ -1,0 +1,151 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/bjarneo/ku/internal/k8s"
+)
+
+func impersonateTestApp(imp k8s.Impersonation) App {
+	return App{
+		theme:       PickTheme("ansi"),
+		keys:        defaultKeys(),
+		client:      &k8s.Client{ContextName: "prod"},
+		res:         k8s.ResourceInfo{Resource: "pods", Kind: "Pod", Namespaced: true},
+		namespace:   "default",
+		width:       160,
+		impersonate: imp,
+	}
+}
+
+func TestImpersonationLabel(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		imp  k8s.Impersonation
+		want string
+	}{
+		{"user", k8s.Impersonation{User: "system:admin"}, "system:admin"},
+		{"one group", k8s.Impersonation{User: "u", Groups: []string{"a"}}, "u +1g"},
+		{"two groups", k8s.Impersonation{User: "u", Groups: []string{"a", "b"}}, "u +2g"},
+		{"uid is not shown", k8s.Impersonation{User: "u", UID: "42"}, "u"},
+		{"no user", k8s.Impersonation{Groups: []string{"a"}}, "(no user) +1g"},
+	} {
+		if got := impersonationLabel(tc.imp); got != tc.want {
+			t.Errorf("%s: impersonationLabel() = %q, want %q", tc.name, got, tc.want)
+		}
+	}
+}
+
+// An active impersonation must always be visible: every call in the session
+// acts as someone else.
+func TestHeaderShowsImpersonationChip(t *testing.T) {
+	app := impersonateTestApp(k8s.Impersonation{User: "system:admin", Groups: []string{"system:masters"}})
+
+	got := ansi.Strip(app.headerView())
+	if !strings.Contains(got, "as system:admin +1g") {
+		t.Fatalf("headerView() = %q, want an \"as\" chip", got)
+	}
+}
+
+func TestHeaderOmitsImpersonationChipWhenUnset(t *testing.T) {
+	app := impersonateTestApp(k8s.Impersonation{})
+
+	got := ansi.Strip(app.headerView())
+	if strings.Contains(got, "as ") {
+		t.Fatalf("headerView() = %q, want no \"as\" chip", got)
+	}
+}
+
+func TestModeNoteCombinesImpersonationAndMode(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		app      App
+		contains []string
+		empty    bool
+	}{
+		{
+			name:  "no mode and no impersonation",
+			app:   App{},
+			empty: true,
+		},
+		{
+			name:     "impersonation only",
+			app:      App{impersonate: k8s.Impersonation{User: "system:admin"}},
+			contains: []string{"Impersonating system:admin"},
+		},
+		{
+			name: "impersonation and read-only",
+			app: App{
+				readOnly:    true,
+				impersonate: k8s.Impersonation{User: "system:admin", Groups: []string{"system:masters"}},
+			},
+			contains: []string{"Impersonating system:admin (groups: system:masters)", "·", "Read-only mode"},
+		},
+		{
+			name:     "read-only only",
+			app:      App{readOnly: true},
+			contains: []string{"Read-only mode"},
+		},
+	} {
+		got := tc.app.modeNote()
+		if tc.empty {
+			if got != "" {
+				t.Errorf("%s: modeNote() = %q, want empty", tc.name, got)
+			}
+			continue
+		}
+		for _, want := range tc.contains {
+			if !strings.Contains(got, want) {
+				t.Errorf("%s: modeNote() = %q, want it to contain %q", tc.name, got, want)
+			}
+		}
+	}
+}
+
+// A context switch rebuilds the client, so the identity has to be kept on the
+// App and handed to the new client. The command itself needs a cluster, so this
+// asserts the state it is built from rather than running it.
+func TestContextSwitchKeepsImpersonation(t *testing.T) {
+	imp := k8s.Impersonation{User: "system:admin", Groups: []string{"system:masters"}}
+	app := impersonateTestApp(imp)
+	app.sel = newSelector(app.theme)
+	app.sel.open(selContext, "Switch context", "context", []selItem{{title: "staging", id: "staging"}}, false)
+
+	next, cmd := app.applySelection(selResult{accepted: true, id: "staging"})
+	if cmd == nil {
+		t.Fatal("applySelection returned no command for a context switch")
+	}
+	na, ok := next.(App)
+	if !ok {
+		t.Fatalf("applySelection returned %T, want App", next)
+	}
+	if na.impersonate.User != imp.User || len(na.impersonate.Groups) != 1 {
+		t.Errorf("impersonate = %+v, want %+v", na.impersonate, imp)
+	}
+	if got := ansi.Strip(na.headerView()); !strings.Contains(got, "as system:admin") {
+		t.Errorf("headerView() = %q, want the \"as\" chip to survive the switch", got)
+	}
+}
+
+// The header drops chips that do not fit. A wide "as" chip must not take the
+// chips after it with it: the filter chip is what keeps a narrowed list from
+// looking like the whole set.
+func TestHeaderKeepsFilterChipWhenImpersonationChipOverflows(t *testing.T) {
+	app := impersonateTestApp(k8s.Impersonation{
+		User:   "system:serviceaccount:kube-system:cluster-admin",
+		Groups: []string{"system:masters"},
+	})
+	app.width = 100
+	app.client = &k8s.Client{ContextName: "production-eu-west-1"}
+	app.namespace = "kube-system"
+	app.table = newTableView(app.theme)
+	app.table.filter.SetValue("nginx")
+
+	got := ansi.Strip(app.headerView())
+	if !strings.Contains(got, "filter /nginx") {
+		t.Fatalf("headerView() = %q, want the filter chip to survive an overflowing \"as\" chip", got)
+	}
+}

--- a/internal/ui/messages.go
+++ b/internal/ui/messages.go
@@ -179,9 +179,9 @@ func startupCmd(opts Options, saved savedState, hasSaved bool) tea.Cmd {
 		if ctxName == "" && hasSaved {
 			ctxName = saved.Context
 		}
-		cl, err := k8s.NewClient(ctxName, opts.Kubeconfig)
+		cl, err := k8s.NewClient(ctxName, opts.Kubeconfig, opts.Impersonate)
 		if err != nil && opts.Context == "" && ctxName != "" {
-			cl, err = k8s.NewClient("", opts.Kubeconfig)
+			cl, err = k8s.NewClient("", opts.Kubeconfig, opts.Impersonate)
 		}
 		if err != nil {
 			return startupReadyMsg{err: err}
@@ -437,9 +437,12 @@ func drainCmd(cl *k8s.Client, name string) tea.Cmd {
 	}
 }
 
-func switchContextCmd(name, kubeconfig string) tea.Cmd {
+// switchContextCmd rebuilds the client for another context. It carries the
+// impersonation forward, so switching context does not silently drop the
+// identity the session was started with.
+func switchContextCmd(name, kubeconfig string, imp k8s.Impersonation) tea.Cmd {
 	return func() tea.Msg {
-		cl, err := k8s.NewClient(name, kubeconfig)
+		cl, err := k8s.NewClient(name, kubeconfig, imp)
 		return clientReadyMsg{client: cl, err: err}
 	}
 }

--- a/internal/ui/run.go
+++ b/internal/ui/run.go
@@ -19,6 +19,9 @@ type Options struct {
 	Version    string // running version, for the background update check ("dev" = skip)
 	Dev        bool   // developer scope: hide cluster admin resources and node ops
 	Edit       bool   // start in edit mode; the session is read-only by default
+	// Impersonate is the identity to act as, from --as/--as-group/--as-uid. The
+	// zero value uses the kubeconfig identity. It is never persisted.
+	Impersonate k8s.Impersonation
 }
 
 // Run starts the interactive TUI. The cluster connection and config load run in
@@ -30,11 +33,11 @@ func Run(opts Options) error {
 	if ctxName == "" && hasSaved {
 		ctxName = saved.Context
 	}
-	if err := k8s.ValidateKubeconfig(ctxName, opts.Kubeconfig); err != nil {
+	if err := k8s.ValidateKubeconfig(ctxName, opts.Kubeconfig, opts.Impersonate); err != nil {
 		if opts.Context != "" || ctxName == "" {
 			return err
 		}
-		if err := k8s.ValidateKubeconfig("", opts.Kubeconfig); err != nil {
+		if err := k8s.ValidateKubeconfig("", opts.Kubeconfig, opts.Impersonate); err != nil {
 			return err
 		}
 	}
@@ -51,6 +54,7 @@ func Run(opts Options) error {
 
 	app := App{theme: th, keys: defaultKeys(), splash: true, opts: opts, saved: saved, hasSaved: hasSaved}
 	app.dev = opts.Dev
+	app.impersonate = opts.Impersonate
 	// Safe by default: the session starts read-only unless --edit is passed. It
 	// can be toggled at runtime from the command palette.
 	app.readOnly = !opts.Edit

--- a/internal/ui/smoke_test.go
+++ b/internal/ui/smoke_test.go
@@ -74,7 +74,7 @@ func mkKey(s string) tea.KeyPressMsg {
 // panic and non-empty output. It needs a reachable cluster only for the client
 // catalog; skipped otherwise.
 func TestAppSmoke(t *testing.T) {
-	cl, err := k8s.NewClient("", "")
+	cl, err := k8s.NewClient("", "", k8s.Impersonation{})
 	if err != nil {
 		t.Skipf("no cluster available: %v", err)
 	}

--- a/internal/ui/util.go
+++ b/internal/ui/util.go
@@ -136,7 +136,7 @@ func paneInnerSize(outer, frame int) int {
 
 // impersonationLabel renders an impersonated identity for the header chip: the
 // user name, plus a group count when groups are set. Kept short on purpose; the
-// full identity is in the help overlay's mode note.
+// flags in full are in the `C` command preview.
 func impersonationLabel(imp k8s.Impersonation) string {
 	s := imp.User
 	if s == "" {

--- a/internal/ui/util.go
+++ b/internal/ui/util.go
@@ -7,6 +7,8 @@ import (
 	"charm.land/bubbles/v2/textinput"
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/x/ansi"
+
+	"github.com/bjarneo/ku/internal/k8s"
 )
 
 func itoa(n int) string { return strconv.Itoa(n) }
@@ -130,4 +132,20 @@ func paneInnerSize(outer, frame int) int {
 		return n
 	}
 	return 1
+}
+
+// impersonationLabel renders an impersonated identity for the header chip: the
+// user name, plus a group count when groups are set. Kept short on purpose; the
+// full identity is in the help overlay's mode note.
+func impersonationLabel(imp k8s.Impersonation) string {
+	s := imp.User
+	if s == "" {
+		// Only reachable if an unvalidated identity gets this far; a bare "as "
+		// with no name reads as a rendering bug rather than a warning.
+		s = "(no user)"
+	}
+	if n := len(imp.Groups); n > 0 {
+		s += " +" + itoa(n) + "g"
+	}
+	return s
 }

--- a/main.go
+++ b/main.go
@@ -5,9 +5,11 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/bjarneo/ku/internal/k8s"
@@ -17,6 +19,21 @@ import (
 
 // version is set at build time with -ldflags "-X main.version=vX.Y.Z".
 var version = "dev"
+
+// groupList collects a repeatable string flag. The stdlib flag package has no
+// slice support and kubectl's --as-group is repeatable, so Set appends instead
+// of replacing.
+type groupList []string
+
+func (g *groupList) String() string { return strings.Join(*g, ",") }
+
+func (g *groupList) Set(v string) error {
+	if v == "" {
+		return errors.New("group must not be empty")
+	}
+	*g = append(*g, v)
+	return nil
+}
 
 func main() {
 	if len(os.Args) > 1 && os.Args[1] == "upgrade" {
@@ -37,6 +54,8 @@ func main() {
 
 	var (
 		ctxFlag, nsFlag, resFlag, themeFlag, kubeconfigFlag string
+		asFlag, asUIDFlag                                   string
+		asGroupFlag                                         groupList
 		checkFlag, versionFlag, devFlag, editFlag           bool
 	)
 	flag.StringVar(&ctxFlag, "context", "", "kubeconfig context to use (default: current-context)")
@@ -45,18 +64,27 @@ func main() {
 	flag.StringVar(&resFlag, "resource", "", "initial resource, e.g. pods, deploy, svc")
 	flag.StringVar(&themeFlag, "theme", "", "color theme: ansi (default) or tokyonight")
 	flag.StringVar(&kubeconfigFlag, "kubeconfig", "", "path to the kubeconfig file (default: $KUBECONFIG or ~/.kube/config)")
+	flag.StringVar(&asFlag, "as", "", "username to impersonate for the session, e.g. system:admin")
+	flag.Var(&asGroupFlag, "as-group", "group to impersonate; repeat the flag for multiple groups")
+	flag.StringVar(&asUIDFlag, "as-uid", "", "uid to impersonate")
 	flag.BoolVar(&devFlag, "dev", false, "developer view: hide cluster admin resources and node ops")
 	flag.BoolVar(&editFlag, "edit", false, "start in edit mode; default is read-only, toggle from the command palette")
 	flag.BoolVar(&checkFlag, "check", false, "run a read-only connectivity check and exit")
 	flag.BoolVar(&versionFlag, "version", false, "print version and exit")
 	flag.Parse()
 
+	imp := k8s.Impersonation{User: asFlag, Groups: asGroupFlag, UID: asUIDFlag}
+	if err := imp.Validate(); err != nil {
+		fmt.Fprintln(os.Stderr, "error:", err)
+		os.Exit(1)
+	}
+
 	switch {
 	case versionFlag:
 		fmt.Println("ku", version)
 		return
 	case checkFlag:
-		if err := check(ctxFlag, kubeconfigFlag, nsFlag, resFlag); err != nil {
+		if err := check(ctxFlag, kubeconfigFlag, nsFlag, resFlag, imp); err != nil {
 			fmt.Fprintln(os.Stderr, "error:", err)
 			os.Exit(1)
 		}
@@ -64,14 +92,15 @@ func main() {
 	}
 
 	if err := ui.Run(ui.Options{
-		Context:    ctxFlag,
-		Namespace:  nsFlag,
-		Resource:   resFlag,
-		Theme:      themeFlag,
-		Kubeconfig: kubeconfigFlag,
-		Version:    version,
-		Dev:        devFlag,
-		Edit:       editFlag,
+		Context:     ctxFlag,
+		Namespace:   nsFlag,
+		Resource:    resFlag,
+		Theme:       themeFlag,
+		Kubeconfig:  kubeconfigFlag,
+		Version:     version,
+		Dev:         devFlag,
+		Edit:        editFlag,
+		Impersonate: imp,
 	}); err != nil {
 		fmt.Fprintln(os.Stderr, "error:", err)
 		os.Exit(1)
@@ -93,16 +122,19 @@ func runUpgrade(args []string) error {
 
 // check performs a read-only listing to validate connectivity and discovery
 // without starting the UI. Useful in non-interactive environments.
-func check(ctxName, kubeconfig, ns, resQuery string) error {
+func check(ctxName, kubeconfig, ns, resQuery string, imp k8s.Impersonation) error {
 	if resQuery == "" {
 		resQuery = "pods"
 	}
-	cl, err := k8s.NewClient(ctxName, kubeconfig)
+	cl, err := k8s.NewClient(ctxName, kubeconfig, imp)
 	if err != nil {
 		return err
 	}
 	fmt.Printf("context:   %s\nhost:      %s\nnamespace: %q\nresources: %d discovered\n",
 		cl.ContextName, cl.Host, cl.Namespace, len(cl.Registry().All()))
+	if imp.Active() {
+		fmt.Printf("as:        %s\n", imp)
+	}
 
 	ri, ok := cl.Registry().Resolve(resQuery)
 	if !ok {

--- a/main_test.go
+++ b/main_test.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"flag"
 	"io"
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/bjarneo/ku/internal/k8s"
 )
 
 func TestRunUpgradeHelpPrintsUsage(t *testing.T) {
@@ -41,4 +44,73 @@ func captureStdout(t *testing.T, f func()) string {
 	}
 	os.Stdout = old
 	return string(b)
+}
+
+// --as-group is repeatable, like kubectl's, so Set must append.
+func TestGroupListFlagRepeats(t *testing.T) {
+	fs := flag.NewFlagSet("ku", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	var groups groupList
+	fs.Var(&groups, "as-group", "group")
+
+	if err := fs.Parse([]string{"--as-group", "system:masters", "--as-group", "devs"}); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got := strings.Join(groups, ","); got != "system:masters,devs" {
+		t.Fatalf("groups = %q, want %q", got, "system:masters,devs")
+	}
+	if got := groups.String(); got != "system:masters,devs" {
+		t.Fatalf("String() = %q, want %q", got, "system:masters,devs")
+	}
+}
+
+func TestGroupListFlagRejectsEmpty(t *testing.T) {
+	fs := flag.NewFlagSet("ku", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	var groups groupList
+	fs.Var(&groups, "as-group", "group")
+
+	if err := fs.Parse([]string{"--as-group", ""}); err == nil {
+		t.Fatal("parse accepted an empty --as-group")
+	}
+}
+
+// Groups or a uid without a user are rejected up front so the error names the
+// flag, rather than surfacing later as a kubeconfig load failure.
+func TestImpersonationFlagValidation(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{"none", nil, ""},
+		{"user", []string{"--as", "system:admin"}, ""},
+		{"user and group", []string{"--as", "system:admin", "--as-group", "system:masters"}, ""},
+		{"group without user", []string{"--as-group", "system:masters"}, "--as-group requires --as"},
+		{"uid without user", []string{"--as-uid", "42"}, "--as-uid requires --as"},
+	} {
+		fs := flag.NewFlagSet("ku", flag.ContinueOnError)
+		fs.SetOutput(io.Discard)
+		var (
+			as, asUID string
+			asGroups  groupList
+		)
+		fs.StringVar(&as, "as", "", "")
+		fs.Var(&asGroups, "as-group", "")
+		fs.StringVar(&asUID, "as-uid", "", "")
+		if err := fs.Parse(tc.args); err != nil {
+			t.Fatalf("%s: parse: %v", tc.name, err)
+		}
+
+		imp := k8s.Impersonation{User: as, Groups: asGroups, UID: asUID}
+		err := imp.Validate()
+		switch {
+		case tc.wantErr == "" && err != nil:
+			t.Errorf("%s: Validate() = %v, want nil", tc.name, err)
+		case tc.wantErr != "" && err == nil:
+			t.Errorf("%s: Validate() = nil, want %q", tc.name, tc.wantErr)
+		case tc.wantErr != "" && err != nil && err.Error() != tc.wantErr:
+			t.Errorf("%s: Validate() = %q, want %q", tc.name, err, tc.wantErr)
+		}
+	}
 }


### PR DESCRIPTION
## What

Adds `--as`, `--as-group`, and `--as-uid` to let the whole session run as another Kubernetes identity, matching the equivalent `kubectl` flags.

For example:

```sh
ku --edit --as system:admin --as-group system:masters
```

This is useful when you need to access objects your normal kubeconfig identity cannot, such as deleting something that requires cluster-admin privileges.

`--as-group` can be specified multiple times.

## How

The flags are turned into a `k8s.Impersonation` in `main.go` and passed through `clientcmd` using the same `AuthInfo.Impersonate`, `ImpersonateGroups`, and `ImpersonateUID` overrides that `kubectl` uses.

From there, the identity ends up on `rest.Config.Impersonate`. All clients and transports in `internal/k8s` are built from that same config, including the clientset, dynamic and discovery clients, exec, port-forward, and WebSocket transports. That means individual call sites don't need to know anything about impersonation.

`Impersonation.Validate` also catches invalid combinations up front, such as specifying a group or UID without a user. `clientcmd` would reject these too, but validating them when the session starts gives a more useful error tied directly to the flags the user provided.

The identity is stored on `App`, so `switchContextCmd` carries it over when rebuilding the client. It is never persisted to `state.json`.

## Behavior

* A warn-styled `as` chip appears in the header while impersonation is active. It shows the impersonated user and group count.
* The `C` command preview includes the impersonation flags, so the generated `kubectl` command matches the session. `--as-group` and `--as-uid` are only shown when `--as` is present, since `kubectl` doesn't accept them on their own.
* `--check` includes an `as:` line showing the active identity.
* Impersonation survives a context switch with `c`, because the rebuilt client keeps the same identity.
* Impersonation is only for the current invocation; the next launch uses the normal identity again.
* It changes **who you are**, not what the session is allowed to do. Edit mode is still read-only unless `--edit` is passed or `Shift+E` is pressed.

## Testing

Added coverage for:

* `internal/k8s/impersonate_test.go`: `Active`, `Validate`, `String`, kubeconfig → `rest.Config` impersonation, and preserving impersonation across context overrides.
* `main_test.go`: repeatable `--as-group`, empty groups, and flag validation.
* `internal/ui/impersonate_test.go`: chip rendering, chip labels, context switches, and chip overflow.
* `internal/ui/command_view_test.go`: impersonation flags in generated commands, omission when unset, and requiring `--as`.
* `internal/ui/help_view_test.go`: wrapping the mode note without widening the modal.

`make test` and `make vet` both pass.
